### PR TITLE
Add support for SwiftKey / SwiftKey Beta 6.2+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.shubhangrathore.xposed.disablefullscreenkeyboard"
         minSdkVersion 14
         targetSdkVersion 20
-        versionCode 3
-        versionName "1.2"
+        versionCode 4
+        versionName "1.3"
     }
     buildTypes {
         release {


### PR DESCRIPTION
I have updated SwiftKey to new version 6.2+ and landscape mode was still in fullscreen, but with empty window and it was not possible to type anything.

I have found the cause. In some newer version of Swiftkey, there was class `com.touchtype.keyboard.service.TouchTypeSoftKeyboard`
replaced with 
`com.touchtype.KeyboardService`

I added support for new class. It can now works with any of these two classes - both past and new versions of SwiftKey will work.
